### PR TITLE
feat: add support for Windows

### DIFF
--- a/change-merged
+++ b/change-merged
@@ -36,15 +36,27 @@ parser.add_option("-b", "--branch", dest="branch_name",
 parser.add_option("-t", "--topic", dest="topic",
     help="Gerrit topic of Changeset")
 parser.add_option("-s", "--submitter", dest="submitter",
-    help="Gerrit Patchset id")
+    help="Gerrit Submitter")
+parser.add_option("--submitter-username", dest="submitter_username",
+    help="Gerrit Submitter User Name")
 parser.add_option("-c", "--commit", dest="commit",
     help="GIT Commit SHA ID")
 parser.add_option("--change-owner", dest="change_owner",
     help="Gerrit Change Owner")
+parser.add_option("--change-owner-username", dest="change_owner_username",
+    help="Gerrit Change Owner User Name")
 parser.add_option("--newrev", dest="new_rev",
     help="Gerrit New Rev")
 
 options, args = parser.parse_args()
+try:
+    idx = sys.argv.index('--topic')
+except ValueError:
+    pass
+else:
+    if sys.argv[idx+1].startswith('--'):
+        sys.argv.insert(idx+1, '')
+        options, args = parser.parse_args()
 
 # run trac update with hook-name and options
 trac_update = TracGerritTicket(hook_name=sys.argv[0],

--- a/change-merged.bat
+++ b/change-merged.bat
@@ -1,0 +1,1 @@
+python D:\gerrit\site\hooks\change-merged %*

--- a/comment-added
+++ b/comment-added
@@ -39,6 +39,8 @@ parser.add_option("-t", "--topic", dest="topic",
     help="Gerrit topic of Changeset")
 parser.add_option("-a", "--author", dest="author",
     help="Gerrit Comment Author", default=None)
+parser.add_option("--author-username", dest="author_username",
+    help="Gerrit Comment Author User Name", default=None)
 parser.add_option("-c", "--commit", dest="commit",
     help="GIT Commit SHA ID")
 parser.add_option("-m", "--comment", dest="comment",
@@ -47,6 +49,8 @@ parser.add_option("--Code-Review", dest="review",
     help="Gerrit Review", default=None)
 parser.add_option("--change-owner", dest="change_owner",
     help="Gerrit Change Owner", default=None)
+parser.add_option("--change-owner-username", dest="change_owner_username",
+    help="Gerrit Change Owner User Name")
 parser.add_option("--Verified", dest="verified",
     help="Gerrit Verified", default=None)
 parser.add_option("--Verified-oldValue", dest="verified_oldValue",
@@ -56,6 +60,14 @@ parser.add_option("--Code-Review-oldValue", dest="review_oldValue",
 
 
 options, args = parser.parse_args()
+try:
+    idx = sys.argv.index('--topic')
+except ValueError:
+    pass
+else:
+    if sys.argv[idx+1].startswith('--'):
+        sys.argv.insert(idx+1, '')
+        options, args = parser.parse_args()
 
 # run trac update with hook-name and options
 trac_update = TracGerritTicket(hook_name=sys.argv[0],

--- a/comment-added.bat
+++ b/comment-added.bat
@@ -1,0 +1,1 @@
+python D:\gerrit\site\hooks\comment-added %*

--- a/patchset-created
+++ b/patchset-created
@@ -35,6 +35,8 @@ parser.add_option("-b", "--branch", dest="branch_name",
     help="Gerrit Branch Name")
 parser.add_option("-l", "--uploader", dest="uploader",
     help="Gerrit Uploader", default=None)
+parser.add_option("--uploader-username", dest="uploader_username",
+    help="Gerrit Uploader User Name", default=None)
 parser.add_option("-c", "--commit", dest="commit",
     help="GIT Commit SHA ID")
 parser.add_option("-u", "--change-url", dest="change_url",
@@ -47,8 +49,18 @@ parser.add_option("-k", "--kind", dest="kind",
     help="Gerrit Change Kind")
 parser.add_option("--change-owner", dest="change_owner",
     help="Gerrit Change Owner")
+parser.add_option("--change-owner-username", dest="change_owner_username",
+    help="Gerrit Change Owner User Name")
 
 options, args = parser.parse_args()
+try:
+    idx = sys.argv.index('--topic')
+except ValueError:
+    pass
+else:
+    if sys.argv[idx+1].startswith('--'):
+        sys.argv.insert(idx+1, '')
+        options, args = parser.parse_args()
 
 # run trac update with hook-name and options
 trac_update = TracGerritTicket(hook_name=sys.argv[0],

--- a/patchset-created.bat
+++ b/patchset-created.bat
@@ -1,0 +1,1 @@
+python D:\gerrit\site\hooks\patchset-created %*

--- a/ref-update
+++ b/ref-update
@@ -31,12 +31,22 @@ parser.add_option("-r", "--refname", dest="refname",
     help="Git ref Name")
 parser.add_option("-u", "--uploader", dest="uploader",
     help="Gerrit Uploader")
+parser.add_option("--uploader-username", dest="uploader_username",
+    help="Gerrit Uploader User Name", default=None)
 parser.add_option("-o", "--oldrev", dest="oldrev",
     help="GIT old rev")
 parser.add_option("-n", "--newrev", dest="newrev",
     help="GIT new rev")
 
 options, args = parser.parse_args()
+try:
+    idx = sys.argv.index('--topic')
+except ValueError:
+    pass
+else:
+    if sys.argv[idx+1].startswith('--'):
+        sys.argv.insert(idx+1, '')
+        options, args = parser.parse_args()
 
 trac_update = TracGerritTicket(hook_name=sys.argv[0],
                                options=options)

--- a/ref-update.bat
+++ b/ref-update.bat
@@ -1,0 +1,2 @@
+exit 0
+python D:\gerrit\site\hooks\ref-update %*


### PR DESCRIPTION
There is a bug to pass empty string arguments to `.bat` on Windows, add a workaround in the python scripts. There is also a bug to pass multiline string arguments to `.bat`, don't know how to fix.